### PR TITLE
카메라 프리뷰 갤러리 버튼 추가, 파일 접근 권한 추가 및 갤러리 접근, 임시로 선택한 이미지 화면 출력

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" 
         android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />


### PR DESCRIPTION
AiCameraDogEye.kt 카메라프리뷰에 갤러리 버튼 추가 진행. 클릭 시, 파일접근권한 설정 후 갤러리에서 이미지 선택 가능. 이미지 선택하면 해당 이미지가 화면에 출력. 하지만 이때 224 크롭기능은 제외함. 